### PR TITLE
Update some switches related to file Main files names and directories…

### DIFF
--- a/Model/CheckAnyMocapConfiguration.any
+++ b/Model/CheckAnyMocapConfiguration.any
@@ -1,15 +1,21 @@
 #ifndef MOCAP_C3D_DATA_PATH 
-#path MOCAP_C3D_DATA_PATH "<ANYBODY_PATH_MAINFILEDIR>"
+#path MOCAP_C3D_DATA_PATH "<MOCAP_PATH_MAINFILEDIR>"
 #endif
 
+// Prefix which can be used by the application to distinques trials
 #ifndef MOCAP_OUTPUT_FILENAME_PREFIX 
  #define MOCAP_OUTPUT_FILENAME_PREFIX ""
+#endif
+
+// Extra prefix which is used by the test framework to avoid overwriting 
+// the orignal files when running automated tests of the AnyMoCap.
+#ifndef MOCAP_TEST_FILENAME_PREFIX
+ #define MOCAP_TEST_FILENAME_PREFIX ""
 #endif
 
 #ifndef BODY_MODEL_CONFIG_FILE 
 #path BODY_MODEL_CONFIG_FILE  "ExampleFiles/BodyModelConfig_FullBody.any"
 #endif
-
 
 #ifndef MOCAP_EXTRA_DRIVERS_FILE 
 #path MOCAP_EXTRA_DRIVERS_FILE "ExampleFiles/ExtraDrivers_PlugInGait.any"
@@ -31,16 +37,12 @@ Main.Studies.ParameterIdentification = {AnyDesVar dummy = {Val = 0;};};
 #endif
 
 //IF the AnyMocapModel is loaded directly: add a example c3d file 
-#if ANYBODY_FILENAME_MAINFILE == "AnyMocapModel.any" & ANYBODY_NAME_MAINFILEDIR == "anymocap"
+#if ANYBODY_FILENAME_MAINFILE == "AnyMocapModel.any" & MOCAP_NAME_MAINFILEDIR == "anymocap"
 Main.ModelSetup.TrialSpecificData.TrialFileName = "C3D_ExampleFile";
 #endif
 
 #ifndef MOCAP_C3DSETTINGS 
 #path  MOCAP_C3DSETTINGS  "C3DSettings.any"
-#endif
-
-#ifndef MOCAP_JOINT_ANGLE_FILE_PREFIX 
-#define MOCAP_JOINT_ANGLE_FILE_PREFIX ""
 #endif
 
 #ifndef BM_CONFIG_VALUES 

--- a/Model/ExampleFiles/TrialSpecificData.any
+++ b/Model/ExampleFiles/TrialSpecificData.any
@@ -5,12 +5,12 @@
 /*
 
  /// This is the name of the trial c3d file without extension
- TrialFileName = ANYBODY_NAME_MAINFILEDIR;
+ TrialFileName = MOCAP_NAME_MAINFILEDIR;
 
 
 
  // This sets the path to where the C3D file is stored
- #path MOCAP_C3D_DATA_PATH "<ANYBODY_PATH_MAINFILEDIR>"
+ #path MOCAP_C3D_DATA_PATH "<MOCAP_PATH_MAINFILEDIR>"
 
  // This prefix is added to all output files.
  #define MOCAP_OUTPUT_FILENAME_PREFIX ""

--- a/Model/JointAngleOutputs.any
+++ b/Model/JointAngleOutputs.any
@@ -28,7 +28,7 @@ AnyFolder JointAngleOutputs = {
   }';
  
   AnyOutputFile OutputFile1 = {
-    FileName = TEMP_PATH+"/"+ MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-trunk.txt";
+    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-trunk.txt";
     SepSign = " ";
     
     AnyVector PelvisPosX = ..BodyModel.Interface.Trunk.PelvisPosX.Pos;
@@ -63,7 +63,7 @@ AnyFolder JointAngleOutputs = {
   }';
 
   AnyOutputFile OutputFile2 = {
-    FileName = TEMP_PATH+"/"+ MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftlegtd.txt";
+    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftlegtd.txt";
     SepSign = " ";
     
     AnyVector HipFlexion = ..BodyModel.Interface.Left.HipFlexion.Pos;
@@ -90,7 +90,7 @@ AnyFolder JointAngleOutputs = {
   }';
   
   AnyOutputFile OutputFile3 = {
-    FileName = TEMP_PATH+"/"+ MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightlegtd.txt";
+    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightlegtd.txt";
     SepSign = " ";
     
     AnyVector HipFlexion = ..BodyModel.Interface.Right.HipFlexion.Pos;
@@ -119,7 +119,7 @@ AnyFolder JointAngleOutputs = {
   }';
   
   AnyOutputFile OutputFile4 = {
-    FileName = TEMP_PATH+"/"+ MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftleg.txt";
+    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftleg.txt";
     SepSign = " ";
     
     AnyVector HipFlexion = ..BodyModel.Interface.Left.HipFlexion.Pos;
@@ -145,7 +145,7 @@ AnyFolder JointAngleOutputs = {
   }';
 
   AnyOutputFile OutputFile5 = {
-    FileName = TEMP_PATH+"/"+ MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightleg.txt";
+    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightleg.txt";
     SepSign = " ";
     
     AnyVector HipFlexion = ..BodyModel.Interface.Right.HipFlexion.Pos;
@@ -176,7 +176,7 @@ AnyFolder JointAngleOutputs = {
   }';
 
   AnyOutputFile OutputFile6 = {
-    FileName = TEMP_PATH+"/"+ MOCAP_JOINT_ANGLE_FILE_PREFIX +MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftarm.txt";
+    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX +MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftarm.txt";
     SepSign = " ";
    
     AnyVector SternoClavicularProtraction=..BodyModel.Interface.Left.SternoClavicularProtraction.Pos;
@@ -209,7 +209,7 @@ AnyFolder JointAngleOutputs = {
   }';
   
   AnyOutputFile OutputFile7 = {
-    FileName = TEMP_PATH+"/"+ MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightarm.txt";
+    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightarm.txt";
     SepSign = " ";
     
     AnyVector SternoClavicularProtraction=..BodyModel.Interface.Right.SternoClavicularProtraction.Pos;

--- a/Model/JointsAndDriversOptimized.any
+++ b/Model/JointsAndDriversOptimized.any
@@ -6,7 +6,7 @@ AnyFolder JointsAndDrivers = {
   
   AnyKinDriver JntDriverTrunk = {
     AnyInputFile FileReader = {
-        FileName = TEMP_PATH + "/" + MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-trunk.txt";
+        FileName = TEMP_PATH + "/" + MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-trunk.txt";
         FileErrorContinueOnOff = On;
         ReloadOnOff = On;
         SuppressWarningsOnOff = On;
@@ -96,7 +96,7 @@ AnyFolder JointsAndDrivers = {
       T = iffun({ValidData}, .FileReader.T, .FileReader.T0);
     };
     AnyInputFile FileReader = {
-        FileName = TEMP_PATH + "/" + MOCAP_JOINT_ANGLE_FILE_PREFIX +MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftlegtd.txt";
+        FileName = TEMP_PATH + "/" + MOCAP_TEST_FILENAME_PREFIX +MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftlegtd.txt";
         FileErrorContinueOnOff = On;
         ReloadOnOff = On;
         SuppressWarningsOnOff = On;
@@ -126,7 +126,7 @@ AnyFolder JointsAndDrivers = {
       T = iffun({ValidData}, .FileReader.T, .FileReader.T0);
     };
     AnyInputFile FileReader = {
-      FileName = TEMP_PATH + "/" + MOCAP_JOINT_ANGLE_FILE_PREFIX +  MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightlegtd.txt";
+      FileName = TEMP_PATH + "/" + MOCAP_TEST_FILENAME_PREFIX +  MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightlegtd.txt";
       FileErrorContinueOnOff = On;
       ReloadOnOff = On;
       SuppressWarningsOnOff = On;
@@ -157,7 +157,7 @@ AnyFolder JointsAndDrivers = {
       T = iffun({ValidData}, .FileReader.T, .FileReader.T0);
     };
     AnyInputFile FileReader = {
-      FileName = TEMP_PATH + "/" + MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftleg.txt";
+      FileName = TEMP_PATH + "/" + MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftleg.txt";
       FileErrorContinueOnOff = On;
       ReloadOnOff = On;
       SuppressWarningsOnOff = On;
@@ -187,7 +187,7 @@ AnyFolder JointsAndDrivers = {
       T = iffun({ValidData}, .FileReader.T, .FileReader.T0);
     };
     AnyInputFile FileReader = {
-      FileName = TEMP_PATH + "/" + MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightleg.txt";
+      FileName = TEMP_PATH + "/" + MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightleg.txt";
       FileErrorContinueOnOff = On;
       ReloadOnOff = On;
       SuppressWarningsOnOff = On;
@@ -218,7 +218,7 @@ AnyFolder JointsAndDrivers = {
       T = iffun({ValidData}, .FileReader.T, .FileReader.T0);
     };
     AnyInputFile FileReader = {
-      FileName = TEMP_PATH + "/" + MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftarm.txt";
+      FileName = TEMP_PATH + "/" + MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-leftarm.txt";
       FileErrorContinueOnOff = On;
       ReloadOnOff = On;
       SuppressWarningsOnOff = On;
@@ -252,7 +252,7 @@ AnyFolder JointsAndDrivers = {
       T = iffun({ValidData}, .FileReader.T, .FileReader.T0);
     };
     AnyInputFile FileReader = {
-      FileName = TEMP_PATH + "/" + MOCAP_JOINT_ANGLE_FILE_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightarm.txt";
+      FileName = TEMP_PATH + "/" + MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-rightarm.txt";
       FileErrorContinueOnOff = On;
       ReloadOnOff = On;
       SuppressWarningsOnOff = On;

--- a/Model/ModelSetup.any
+++ b/Model/ModelSetup.any
@@ -53,21 +53,21 @@ ModelSetup = {
     AnyOperationMacro SaveOutputToHDF = {
        MacroStr = { "classoperation Main.Studies.KinematicStudy.Output" + strquote("Save data") +
                     "--type= " + strquote("Deep") + 
-                    "--file= " + strquote(ANYBODY_PATH_OUTPUT + "/" + 
+                    "--file= " + strquote(ANYBODY_PATH_OUTPUT + "/" + MOCAP_TEST_FILENAME_PREFIX +  MOCAP_OUTPUT_FILENAME_PREFIX +
                     Main.ModelSetup.TrialSpecificData.TrialFileName + "_KinematicStudy.anydata.h5"),
                     
                     "classoperation Main.Studies.InverseDynamicStudy.Output" + strquote("Save data") +
                     "--type= " + strquote("Deep") + 
-                    "--file= " + strquote(ANYBODY_PATH_OUTPUT + "/" + 
+                    "--file= " + strquote(ANYBODY_PATH_OUTPUT + "/" + MOCAP_TEST_FILENAME_PREFIX  +  MOCAP_OUTPUT_FILENAME_PREFIX +
                     Main.ModelSetup.TrialSpecificData.TrialFileName + "_InverseDynamicStudy.anydata.h5")};
     };
     AnyOperationMacro LoadOutputFromHDF = {
        MacroStr = { "classoperation Main.Studies.KinematicStudy.Output" + strquote("Load data") +
-                    "--file= " + strquote(ANYBODY_PATH_OUTPUT + "/" + 
+                    "--file= " + strquote(ANYBODY_PATH_OUTPUT + "/" + MOCAP_TEST_FILENAME_PREFIX +  MOCAP_OUTPUT_FILENAME_PREFIX +
                     Main.ModelSetup.TrialSpecificData.TrialFileName + "_KinematicStudy.anydata.h5"),
                     
                     "classoperation Main.Studies.InverseDynamicStudy.Output" + strquote("Load data") +
-                    "--file= " + strquote(ANYBODY_PATH_OUTPUT + "/" + 
+                    "--file= " + strquote(ANYBODY_PATH_OUTPUT + "/" + MOCAP_TEST_FILENAME_PREFIX +  MOCAP_OUTPUT_FILENAME_PREFIX +
                     Main.ModelSetup.TrialSpecificData.TrialFileName + "_InverseDynamicStudy.anydata.h5")};
     };
  

--- a/Model/PathDefinitions.any
+++ b/Model/PathDefinitions.any
@@ -7,6 +7,23 @@
 // are exist if they have not been set by the application 
 // that loads the AnyMocap model.
 
+
+  #ifndef MOCAP_PATH_MAINFILE 
+    #path MOCAP_PATH_MAINFILE ANYBODY_PATH_MAINFILE
+  #endif
+  
+  #ifndef MOCAP_PATH_MAINFILEDIR
+    #path MOCAP_PATH_MAINFILEDIR "<ANYBODY_PATH_MAINFILEDIR>"
+  #endif
+  
+  #ifndef MOCAP_NAME_MAINFILE
+    #define MOCAP_NAME_MAINFILE ANYBODY_NAME_MAINFILE
+  #endif
+  
+  #ifndef MOCAP_NAME_MAINFILEDIR
+    #define MOCAP_NAME_MAINFILEDIR ANYBODY_NAME_MAINFILEDIR
+  #endif
+
   #ifndef ANYMOCAP_MODEL_PATH
     #path ANYMOCAP_MODEL_PATH "."
   #endif
@@ -18,7 +35,7 @@
 
   // Path for saving model output files 
   #ifndef ANYBODY_PATH_OUTPUT
-    #path ANYBODY_PATH_OUTPUT "<ANYBODY_PATH_MAINFILEDIR>"
+    #path ANYBODY_PATH_OUTPUT "<MOCAP_PATH_MAINFILEDIR>"
   #endif
    
   #ifndef PROJECT_PATH

--- a/Model/SaveLoadParameters.any
+++ b/Model/SaveLoadParameters.any
@@ -25,7 +25,7 @@
       AnyOperationMacro SaveToFile = {
         AnyFileVar SavePath = TEMP_PATH;
         MacroStr  = {"classoperation Main" + strquote("Save Values") +"--file=" + 
-          strquote(FilePathCompleteOf(SavePath) +"/"+ MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName +".anyset" )
+          strquote(FilePathCompleteOf(SavePath) +"/"+  MOCAP_TEST_FILENAME_PREFIX +MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName +".anyset" )
         };
         
       };
@@ -40,7 +40,7 @@ Main.ModelSetup.Macros = {
   
   #define _GET_VALID_INDEX(X) iffun(gtfun(NumElemOf(Main.ModelSetup.TrialSpecificData.LoadParametersFrom), X), X, 0)
   #define _LOAD_MACRO(X) iffun( gtfun(NumElemOf(Main.ModelSetup.TrialSpecificData.LoadParametersFrom), X) ,\
-                                  "classoperation Main " + strquote("Load Values") +" --file=" + strquote( FilePathCompleteOf(LoadPath)+ "/" +MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.LoadParametersFrom[ _GET_VALID_INDEX(X)]+".anyset") ,\
+                                  "classoperation Main " + strquote("Load Values") +" --file=" + strquote( FilePathCompleteOf(LoadPath)+ "/" + MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.LoadParametersFrom[ _GET_VALID_INDEX(X)]+".anyset") ,\
                                   "")
  
   AnyOperationMacro Load_parameters = {

--- a/Model/TrialSubjectLabSpecificDataTemplates.any
+++ b/Model/TrialSubjectLabSpecificDataTemplates.any
@@ -8,7 +8,7 @@
 
 
 /// This is the name of the trial c3d file without extension
-#var AnyStringVar  TrialFileName = ANYBODY_NAME_MAINFILEDIR;
+#var AnyStringVar  TrialFileName = MOCAP_NAME_MAINFILEDIR;
 
 /// The calibraiton filename (static/dynamic) from which to load the
 /// the optimized parameters.

--- a/Tests/Test_InitialPosExample.any
+++ b/Tests/Test_InitialPosExample.any
@@ -6,6 +6,10 @@
 
 #include "libdef.any"
 
+#path MOCAP_PATH_MAINFILEDIR "../Examples/SpecialFeatures"
+#path MOCAP_PATH_MAINFILE "<MOCAP_PATH_MAINFILEDIR>/InitialPosExample.any"
+#define MOCAP_NAME_MAINFILEDIR "SpecialFeatures"
+
 #path TEMP_PATH "Output"
 
 #include "../Examples/SpecialFeatures/InitialPosExample.any"

--- a/Tests/Test_LowerExtremity-Plug-in-gait.any
+++ b/Tests/Test_LowerExtremity-Plug-in-gait.any
@@ -7,5 +7,36 @@
 
 
 #path TEMP_PATH "Output"
+#path MOCAP_PATH_MAINFILEDIR "../Examples/Plug-in-gait-LowerExtremity"
+#path MOCAP_PATH_MAINFILE "<MOCAP_PATH_MAINFILEDIR>/Main.any"
+#define MOCAP_NAME_MAINFILEDIR "Plug-in-gait-LowerExtremity"
 
-#include "../Examples/Plug-in-gait-LowerExtremity/Main.any"
+
+#ifdef TEST_NAME
+#define  MOCAP_TEST_FILENAME_PREFIX  TEST_NAME + "_"
+#else
+#define  MOCAP_TEST_FILENAME_PREFIX  "GUI_"
+#endif
+
+
+// Run Analysis with a reduced number of time steps
+// to make test go faster. 
+#define N_STEP_PARAM_OPT 10
+#define N_STEP_KINEMATICS 197
+#define N_STEP 30
+
+#path TEMP_PATH "Output"
+
+#include "<MOCAP_PATH_MAINFILE>"
+
+Main = 
+{
+  AnyOperationSequence  RunTest = 
+  {
+    AnyOperation& ParameterId =  Main.RunParameterIdentification;
+    AnyOperation& RunAnalysis = Main.RunAnalysis; 
+  };
+
+  
+  
+};

--- a/Tests/Test_Plug-in-gait_Main.any
+++ b/Tests/Test_Plug-in-gait_Main.any
@@ -5,7 +5,6 @@
 //ignore_errors = ['FileReader.FileName']
 
 
-
 // Test related setup.
 #ifndef TLEM_VERSION
 #define TLEM_VERSION "2.0"
@@ -15,20 +14,25 @@
 
 
 #path TEMP_PATH "Output"
+#path MOCAP_PATH_MAINFILEDIR "../Examples/Plug-in-gait-FullBody"
+#path MOCAP_PATH_MAINFILE "<MOCAP_PATH_MAINFILEDIR>/Main.any"
+#define MOCAP_NAME_MAINFILEDIR "Plug-in-gait-FullBody"
+
+
 #ifdef TEST_NAME
-#define MOCAP_OUTPUT_FILENAME_PREFIX TEST_NAME + "_"
+#define  MOCAP_TEST_FILENAME_PREFIX  TEST_NAME + "_"
 #else
-#define MOCAP_OUTPUT_FILENAME_PREFIX "GUI_"
+#define  MOCAP_TEST_FILENAME_PREFIX  "GUI_"
 #endif
-#path MOCAP_C3D_DATA_PATH "../Examples/Plug-in-gait-FullBody"
+
 
 // Run Analysis with a reduced number of time steps
 // to make test go faster. 
 #define N_STEP_PARAM_OPT 10
 #define N_STEP_KINEMATICS 197
-#define N_STEP 100
+#define N_STEP 30
 
-#include "../Examples/Plug-in-gait-FullBody/Main.any"
+#include "<MOCAP_PATH_MAINFILE>"
 
 Main = 
 {


### PR DESCRIPTION
Update some switches related to file Main files names and directories to make testing easier.

This overloads the ANYBODY_* switches with MOCAP specific version. It has the advantages that we can set these switches from the test framework.

This commit also updates adds a switch MOCAP_TEST_FILENAME_PREFIX to prefix output variables which is intended to be used by the test framework.