### PR TITLE
Fix bug in CreateMarkerDriver class_template

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Current development
   * Use the TLEM 2 lower body model in the example. 
   * Disable upper bounds for the muscle recruitment ``Criterion.UpperBoundOnOff = Off;`` to improve the stability of the simulations. 
   
+* Fix bug in ``CreateMarkerDriver``  class template which prevented the ``UseC3DWeightResiduals`` from having any effect.
 
 
 

--- a/Model/CreateMarkerDriverClass.any
+++ b/Model/CreateMarkerDriverClass.any
@@ -39,7 +39,7 @@
   #var AnyVar ConstMarkerWeightY = WeightY;
   #var AnyVar ConstMarkerWeightZ = WeightZ;
   
-  #if (UseC3DWeightResiduals == 1) & (USE_BVH_INPUT != 0)
+  #if (UseC3DWeightResiduals == 1) & (USE_BVH_INPUT == 0)
     AnyFunSquareWaveThreshold MarkerWeightsFun = 
     {
       #var dT = {C3D_OBJECT.WeightTransitionTime};


### PR DESCRIPTION
This bug prevented the ``UseC3DWeightResiduals`` from having any effect.
This was a regression from adding the BVH functionality to the AnyMoCap
framework

@mariajnsson This could have an influence on your models. I know you used this feature in your models, and it hasn't worked since the AnyMocap was included in the AMMR 2. 

