### PR TITLE
Update structure in AutoPelvisPos to provide better error messages

### DIFF
--- a/Model/AutomaticInitialPositionOfBody.any
+++ b/Model/AutomaticInitialPositionOfBody.any
@@ -9,11 +9,17 @@ T_START = Main.Studies.InverseDynamicStudy.tStart,
 MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
 ) {
     #if DIRECT_PELVIS_POS == 0
-      #var AnyVar tStart = T_START;
+      #var AnyVar tStart = T_START;      
+      
+      AnyParamFun &Pelvis_RASIS_ref = C3D_OBJECT.Points.Markers.RASIS;
+      AnyParamFun &Pelvis_LASIS_ref = C3D_OBJECT.Points.Markers.RASIS;
+      AnyParamFun &Pelvis_BACK_ref = C3D_OBJECT.Points.Markers.RASIS;
+      
+      
       // construct the position vector and rotation matrix from the values in the C3D file.
-      #var AnyVec3 Pelvis_RASIS = C3D_OBJECT.Points.Markers.RASIS.PosInterpol(tStart);
-      #var AnyVec3 Pelvis_LASIS = C3D_OBJECT.Points.Markers.LASIS.PosInterpol(tStart);
-      #var AnyVec3 Pelvis_Back = Main.ModelSetup.C3DFileData.Points.Markers.BACK.PosInterpol(tStart);
+      #var AnyVec3 Pelvis_RASIS = Pelvis_RASIS_ref.PosInterpol(tStart);
+      #var AnyVec3 Pelvis_LASIS = Pelvis_LASIS_ref.PosInterpol(tStart);
+      #var AnyVec3 Pelvis_Back = Pelvis_BACK_ref.PosInterpol(tStart);
     
       #var AnyVec3 PelvisPos = 0.5*(Pelvis_RASIS + Pelvis_LASIS) - 0.02*PelvisRotMat'[0] - 0.01*PelvisRotMat'[1];
       #var AnyMat33 PelvisRotMat = RotMat(Pelvis_LASIS, Pelvis_RASIS, Pelvis_Back)


### PR DESCRIPTION
The AnyScript code structure in AutoPelvisPos prevented the
CreateMarkerDriver class template from providing sensible error
messages when the markers used in AutoPelvisPos were missing.

This is most likely a bug/curiosity in the AMS parser system.
The current restructure of AutoPelvisPos fixes problem.