### PR TITLE
Changed the default velocity threshold value for the ForcePlateAutodection

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,7 +34,10 @@ Current development
   Sterno Clavicula Elevation the Scapula Thorax Elevation is used to make the 
   the kinematics of scapula more robust in the inverse dynamic analysis.
 
-
+* Changed the default velocity threshold value for the ForcePlateAutodetection
+  class template.   This prevents the accidental contact detection of the
+  collateral leg in the swing phase.   The new velocity threshold is set to 1 m/s,
+  or 3.6 km/h.
 
 
 2.0.0

--- a/Model/ForcePlates/ForcePlateAutoDetection.any
+++ b/Model/ForcePlates/ForcePlateAutoDetection.any
@@ -11,7 +11,7 @@
     LIMB2 = Main.HumanModel.BodyModel.Left.Leg.Seg.Foot,
     VerticalDirection = "Automatic",
     HeightTolerance = 0.07,
-    VelThreshold = 2.2, 
+    VelThreshold = 1, 
     FORCEPLATE_TYPE,
     CREATE_KIN_GRF = 0,
     KIN_GRF_LIMB1_FUN = GlobalCopFun,


### PR DESCRIPTION
This prevents the accidental contact detection of the collateral leg in the
swing phase. The new default velocity threshold is set to 1 m/s