### PR TITLE
Prevent multi limb contact for force plates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,7 +35,7 @@ Current development
   the kinematics of scapula more robust in the inverse dynamic analysis.
 
 * Added an option to the ForcePlateAutoDetection class template to make the limb1/2 contact detection 
-  mutually exclusive. Setting the option ``EXLCLUSIVE_LIMB_CONTACT=ON`` will ensure that both legs cant 
+  mutually exclusive. Setting the option ``ALLOW_MULTI_LIMB_CONTACT=OFF`` will ensure that both legs cant 
   be in contact with the plate at the same time. This can prevent accidental contact detection 
   for the collateral leg in the swing phase. 
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,10 +34,10 @@ Current development
   Sterno Clavicula Elevation the Scapula Thorax Elevation is used to make the 
   the kinematics of scapula more robust in the inverse dynamic analysis.
 
-* Changed the default velocity threshold value for the ForcePlateAutodetection
-  class template.   This prevents the accidental contact detection of the
-  collateral leg in the swing phase.   The new velocity threshold is set to 1 m/s,
-  or 3.6 km/h.
+* Added an option to the ForcePlateAutoDetection class template to make the limb1/2 contact detection 
+  mutually exclusive. Setting the option ``EXLCLUSIVE_LIMB_CONTACT=ON`` will ensure that both legs cant 
+  be in contact with the plate at the same time. This can prevent accidental contact detection 
+  for the collateral leg in the swing phase. 
 
 
 2.0.0

--- a/Examples/Plug-in-gait_MultiTrial_StandingRef/ForcePlates.any
+++ b/Examples/Plug-in-gait_MultiTrial_StandingRef/ForcePlates.any
@@ -4,14 +4,14 @@ Main.EnvironmentModel.ForcePlates =
   // See forceplate specification for which option 
   // are available for the ForcePlateAutoDetection class:
   // #include "<ANYMOCAP_PATH>/ForcePlates/ForcePlateAutoDetection.any"
-  // The EXLCLUSIVE_LIMB_CONTACT ensures the class can't create contact 
+  // The ``ALLOW_MULTI_LIMB_CONTACT=OFF`` ensures the class can't create contact 
   // with both limbs simulatenously
   
   ForcePlateAutoDetection Plate1(
     PLATE_NO=1,
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
-    EXLCLUSIVE_LIMB_CONTACT = ON,
+    ALLOW_MULTI_LIMB_CONTACT = OFF,
     FORCEPLATE_TYPE = 4
   ) = { };
   
@@ -19,7 +19,7 @@ Main.EnvironmentModel.ForcePlates =
     PLATE_NO=2,
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
-    EXLCLUSIVE_LIMB_CONTACT = ON,
+    ALLOW_MULTI_LIMB_CONTACT = OFF,
     FORCEPLATE_TYPE = 4
   ) = { };
   

--- a/Examples/Plug-in-gait_MultiTrial_StandingRef/ForcePlates.any
+++ b/Examples/Plug-in-gait_MultiTrial_StandingRef/ForcePlates.any
@@ -4,11 +4,14 @@ Main.EnvironmentModel.ForcePlates =
   // See forceplate specification for which option 
   // are available for the ForcePlateAutoDetection class:
   // #include "<ANYMOCAP_PATH>/ForcePlates/ForcePlateAutoDetection.any"
+  // The EXLCLUSIVE_LIMB_CONTACT ensures the class can't create contact 
+  // with both limbs simulatenously
   
   ForcePlateAutoDetection Plate1(
     PLATE_NO=1,
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
+    EXLCLUSIVE_LIMB_CONTACT = ON,
     FORCEPLATE_TYPE = 4
   ) = { };
   
@@ -16,6 +19,7 @@ Main.EnvironmentModel.ForcePlates =
     PLATE_NO=2,
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
+    EXLCLUSIVE_LIMB_CONTACT = ON,
     FORCEPLATE_TYPE = 4
   ) = { };
   

--- a/Examples/Plug-in-gait_Simple/Setup/ForcePlates.any
+++ b/Examples/Plug-in-gait_Simple/Setup/ForcePlates.any
@@ -4,26 +4,31 @@ Main.EnvironmentModel.ForcePlates =
   // See forceplate specification for which option 
   // are available for the ForcePlateAutoDetection class:
   // #include "<ANYMOCAP_PATH>/ForcePlates/ForcePlateAutoDetection.any"
+  // The EXLCLUSIVE_LIMB_CONTACT ensures the class can't create contact 
+  // with both limbs simulatenously
   
   ForcePlateAutoDetection Plate1(
     PLATE_NO=1,
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
     FORCEPLATE_TYPE = 4
+    EXLCLUSIVE_LIMB_CONTACT = ON,
   ) = { };
   
   ForcePlateAutoDetection Plate2(
     PLATE_NO=2,
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
-    FORCEPLATE_TYPE = 4
+    FORCEPLATE_TYPE = 4,
+    EXLCLUSIVE_LIMB_CONTACT = ON,
   ) = { };
   
   ForcePlateAutoDetection Plate3 (
     PLATE_NO=3,
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
-    FORCEPLATE_TYPE = 4
+    FORCEPLATE_TYPE = 4,
+    EXLCLUSIVE_LIMB_CONTACT = ON,
   ) = { };
 
 };

--- a/Examples/Plug-in-gait_Simple/Setup/ForcePlates.any
+++ b/Examples/Plug-in-gait_Simple/Setup/ForcePlates.any
@@ -4,15 +4,15 @@ Main.EnvironmentModel.ForcePlates =
   // See forceplate specification for which option 
   // are available for the ForcePlateAutoDetection class:
   // #include "<ANYMOCAP_PATH>/ForcePlates/ForcePlateAutoDetection.any"
-  // The EXLCLUSIVE_LIMB_CONTACT ensures the class can't create contact 
+  // The ``ALLOW_MULTI_LIMB_CONTACT=OFF`` ensures the class can't create contact 
   // with both limbs simulatenously
   
   ForcePlateAutoDetection Plate1(
     PLATE_NO=1,
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
-    FORCEPLATE_TYPE = 4
-    EXLCLUSIVE_LIMB_CONTACT = ON,
+    FORCEPLATE_TYPE = 4,
+    ALLOW_MULTI_LIMB_CONTACT = OFF
   ) = { };
   
   ForcePlateAutoDetection Plate2(
@@ -20,7 +20,7 @@ Main.EnvironmentModel.ForcePlates =
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
     FORCEPLATE_TYPE = 4,
-    EXLCLUSIVE_LIMB_CONTACT = ON,
+    ALLOW_MULTI_LIMB_CONTACT = OFF
   ) = { };
   
   ForcePlateAutoDetection Plate3 (
@@ -28,7 +28,7 @@ Main.EnvironmentModel.ForcePlates =
     HeightTolerance = 0.07,
     VelThreshold = 2.2,
     FORCEPLATE_TYPE = 4,
-    EXLCLUSIVE_LIMB_CONTACT = ON,
+    ALLOW_MULTI_LIMB_CONTACT = OFF
   ) = { };
 
 };

--- a/Model/AutomaticInitialPositionOfBody.any
+++ b/Model/AutomaticInitialPositionOfBody.any
@@ -11,15 +11,17 @@ MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
     #if DIRECT_PELVIS_POS == 0
       #var AnyVar tStart = T_START;      
       
-      AnyParamFun &Pelvis_RASIS_ref = C3D_OBJECT.Points.Markers.RASIS;
-      AnyParamFun &Pelvis_LASIS_ref = C3D_OBJECT.Points.Markers.RASIS;
-      AnyParamFun &Pelvis_BACK_ref = C3D_OBJECT.Points.Markers.RASIS;
-      
+      // Calculate the index in the C3D data which corresponds to the tStart  variable.
+      AnyFloat tStartC3D = C3D_OBJECT.Header.FirstFrameNo/C3D_OBJECT.Header.VideoFrameRate;
+      AnyFloat tEndC3D = (C3D_OBJECT.Header.LastFrameNo+1)/C3D_OBJECT.Header.VideoFrameRate;
+      AnyInt nC3d = C3D_OBJECT.Header.LastFrameNo-C3D_OBJECT.Header.FirstFrameNo+1;
+      AnyFloat closest_idx = (nC3d)/(tEndC3D-tStartC3D)*(tStart -tStartC3D);
+      AnyInt start_idx = round( max({0.0,  min({closest_idx, nC3d } )}));
       
       // construct the position vector and rotation matrix from the values in the C3D file.
-      #var AnyVec3 Pelvis_RASIS = Pelvis_RASIS_ref.PosInterpol(tStart);
-      #var AnyVec3 Pelvis_LASIS = Pelvis_LASIS_ref.PosInterpol(tStart);
-      #var AnyVec3 Pelvis_Back = Pelvis_BACK_ref.PosInterpol(tStart);
+      #var AnyVec3 Pelvis_RASIS = C3D_OBJECT.Points.Markers.RASIS.Pos[start_idx];
+      #var AnyVec3 Pelvis_LASIS = C3D_OBJECT.Points.Markers.LASIS.Pos[start_idx];
+      #var AnyVec3 Pelvis_Back = C3D_OBJECT.Points.Markers.BACK.Pos[start_idx];
     
       #var AnyVec3 PelvisPos = 0.5*(Pelvis_RASIS + Pelvis_LASIS) - 0.02*PelvisRotMat'[0] - 0.01*PelvisRotMat'[1];
       #var AnyMat33 PelvisRotMat = RotMat(Pelvis_LASIS, Pelvis_RASIS, Pelvis_Back)

--- a/Model/ForcePlates/ForcePlateAutoDetection.any
+++ b/Model/ForcePlates/ForcePlateAutoDetection.any
@@ -11,7 +11,8 @@
     LIMB2 = Main.HumanModel.BodyModel.Left.Leg.Seg.Foot,
     VerticalDirection = "Automatic",
     HeightTolerance = 0.07,
-    VelThreshold = 1, 
+    VelThreshold = 2.2, 
+    EXLCLUSIVE_LIMB_CONTACT = 0,
     FORCEPLATE_TYPE,
     CREATE_KIN_GRF = 0,
     KIN_GRF_LIMB1_FUN = GlobalCopFun,
@@ -341,8 +342,15 @@
     #include "ContactDetection.any"
     
     AnyMuscleModelUsr1 InContactMuscle = {
+      /// If the ExclusiveContact option is ON this ensures that two limbs can't
+      /// have contact with the plate at the same time
+      /// UseOpositeLimb is 1 if opposite limb has contact and a lower velocity that limb1
+      AnyVar UseOpositeLimb = EXLCLUSIVE_LIMB_CONTACT*
+            andfun(..ContactDetectionLimb2.NodeWithInBox.WithinBoxAndVelBelowThreshold,
+                   ltfun(..ContactDetectionLimb2.NodeWithInBox.P1Vel, .P1Vel)));
+     
       F0 = 0;
-      S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000;
+      S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000*not(UseOpositeLimb);
     };
     
     AnyMuscleModelUsr1 NoContactMuscle = {
@@ -377,8 +385,15 @@
     #include "ContactDetection.any"
     
     AnyMuscleModelUsr1 InContactMuscle = {
+      /// If the ExclusiveContact option is ON this ensures that two limbs can't
+      /// have contact with the plate at the same time
+      /// UseOpositeLimb is 1 if opposite limb has contact and a lower velocity that limb1
+      AnyVar UseOpositeLimb = EXLCLUSIVE_LIMB_CONTACT*
+            andfun(..ContactDetectionLimb1.NodeWithInBox.WithinBoxAndVelBelowThreshold,
+                   ltfun(..ContactDetectionLimb1.NodeWithInBox.P1Vel, .P1Vel)));
+     
       F0 = 0;
-      S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000;
+      S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000*not(UseOpositeLimb);
     };
     
     AnyMuscleModelUsr1 NoContactMuscle = {

--- a/Model/ForcePlates/ForcePlateAutoDetection.any
+++ b/Model/ForcePlates/ForcePlateAutoDetection.any
@@ -344,13 +344,13 @@
     AnyMuscleModelUsr1 InContactMuscle = {
       /// If the ExclusiveContact option is ON this ensures that two limbs can't
       /// have contact with the plate at the same time
-      /// UseOpositeLimb is 1 if opposite limb has contact and a lower velocity that limb1
-      AnyVar UseOpositeLimb = EXLCLUSIVE_LIMB_CONTACT*
+      /// UseOppositeLimb is 1 if the opposite limb has contact and a lower velocity that limb1
+      AnyVar UseOppositeLimb = EXLCLUSIVE_LIMB_CONTACT*
             andfun(..ContactDetectionLimb2.NodeWithInBox.WithinBoxAndVelBelowThreshold,
                    ltfun(..ContactDetectionLimb2.NodeWithInBox.P1Vel, .P1Vel)));
      
       F0 = 0;
-      S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000*not(UseOpositeLimb);
+      S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000*not(UseOppositeLimb);
     };
     
     AnyMuscleModelUsr1 NoContactMuscle = {
@@ -387,13 +387,13 @@
     AnyMuscleModelUsr1 InContactMuscle = {
       /// If the ExclusiveContact option is ON this ensures that two limbs can't
       /// have contact with the plate at the same time
-      /// UseOpositeLimb is 1 if opposite limb has contact and a lower velocity that limb1
-      AnyVar UseOpositeLimb = EXLCLUSIVE_LIMB_CONTACT*
+      /// UseOppositeLimb is 1 if the opposite limb has contact and a lower velocity that limb2
+      AnyVar UseOppositeLimb = EXLCLUSIVE_LIMB_CONTACT*
             andfun(..ContactDetectionLimb1.NodeWithInBox.WithinBoxAndVelBelowThreshold,
                    ltfun(..ContactDetectionLimb1.NodeWithInBox.P1Vel, .P1Vel)));
      
       F0 = 0;
-      S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000*not(UseOpositeLimb);
+      S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000*not(UseOppositeLimb);
     };
     
     AnyMuscleModelUsr1 NoContactMuscle = {

--- a/Model/ForcePlates/ForcePlateAutoDetection.any
+++ b/Model/ForcePlates/ForcePlateAutoDetection.any
@@ -12,7 +12,7 @@
     VerticalDirection = "Automatic",
     HeightTolerance = 0.07,
     VelThreshold = 2.2, 
-    EXLCLUSIVE_LIMB_CONTACT = 0,
+    ALLOW_MULTI_LIMB_CONTACT = 1,
     FORCEPLATE_TYPE,
     CREATE_KIN_GRF = 0,
     KIN_GRF_LIMB1_FUN = GlobalCopFun,
@@ -342,12 +342,12 @@
     #include "ContactDetection.any"
     
     AnyMuscleModelUsr1 InContactMuscle = {
-      /// If the ExclusiveContact option is ON this ensures that two limbs can't
+      /// If the ALLOW_MULTI_LIMB_CONTACT option is OFF this ensures that two limbs can't
       /// have contact with the plate at the same time
       /// UseOppositeLimb is 1 if the opposite limb has contact and a lower velocity that limb1
-      AnyVar UseOppositeLimb = EXLCLUSIVE_LIMB_CONTACT*
+      AnyVar UseOppositeLimb = not(ALLOW_MULTI_LIMB_CONTACT)*
             andfun(..ContactDetectionLimb2.NodeWithInBox.WithinBoxAndVelBelowThreshold,
-                   ltfun(..ContactDetectionLimb2.NodeWithInBox.P1Vel, .P1Vel)));
+                   ltfun(..ContactDetectionLimb2.P1Vel, .P1Vel));
      
       F0 = 0;
       S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000*not(UseOppositeLimb);
@@ -385,12 +385,12 @@
     #include "ContactDetection.any"
     
     AnyMuscleModelUsr1 InContactMuscle = {
-      /// If the ExclusiveContact option is ON this ensures that two limbs can't
+      /// If the ALLOW_MULTI_LIMB_CONTACT option is OFF this ensures that two limbs can't
       /// have contact with the plate at the same time
       /// UseOppositeLimb is 1 if the opposite limb has contact and a lower velocity that limb2
-      AnyVar UseOppositeLimb = EXLCLUSIVE_LIMB_CONTACT*
+      AnyVar UseOppositeLimb = not(ALLOW_MULTI_LIMB_CONTACT)*
             andfun(..ContactDetectionLimb1.NodeWithInBox.WithinBoxAndVelBelowThreshold,
-                   ltfun(..ContactDetectionLimb1.NodeWithInBox.P1Vel, .P1Vel)));
+                   ltfun(..ContactDetectionLimb1.P1Vel, .P1Vel));
      
       F0 = 0;
       S = .NodeWithInBox.WithinBoxAndVelBelowThreshold *10000*not(UseOppositeLimb);


### PR DESCRIPTION
Added an option to the ForcePlateAutoDetection class template to make the limb1/2 contact detection mutually exclusive. Setting the option ``ALLOW_MULTI_LIMB_CONTACT=OFF`` will ensure that both legs cant is in contact with the plate at the same time. This can prevent accidental contact detection for the collateral leg in the swing phase. 